### PR TITLE
Phase 1.5: Responsive layout & content expansion for large screens

### DIFF
--- a/website/src/components/landing-page/about-section.tsx
+++ b/website/src/components/landing-page/about-section.tsx
@@ -3,12 +3,33 @@ import ExpandableCard from "../ui/expandable-card";
 
 const AboutSection = () => {
     return (
-        <div className="min-h-screen bg-gradient-to-b from-purple-600 to-indigo-900 flex items-center justify-center p-8 pt-24 md:pt-12">
-            <div className="max-w-4xl text-center text-white">
+        <div className="bg-gradient-to-b from-purple-600 to-indigo-900 py-20 md:py-28 px-8">
+            <div className="max-w-6xl mx-auto text-center text-white">
                 <h2 className="text-2xl md:text-4xl font-bold mb-6">About Me</h2>
-                <p className="text-base md:text-xl mb-4 md:mb-8">
+                <p className="text-base md:text-xl mb-8 md:mb-12 max-w-3xl mx-auto">
                     Staff Software Engineer at Apple, where I build the infrastructure for AI Agents — observability pipelines, evaluation frameworks, and the platforms that make AI reliable at scale. 13+ years of engineering across Apple, Flipkart, and my own ventures, now fully focused on the frontier of AI-native systems.
                 </p>
+
+                {/* Stats strip */}
+                <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-12 md:mb-16">
+                    <div className="bg-white bg-opacity-10 rounded-xl py-4 px-2">
+                        <p className="text-2xl md:text-3xl font-bold text-yellow-300">13+</p>
+                        <p className="text-xs md:text-sm text-purple-200 uppercase tracking-wider mt-1">Years Engineering</p>
+                    </div>
+                    <div className="bg-white bg-opacity-10 rounded-xl py-4 px-2">
+                        <p className="text-2xl md:text-3xl font-bold text-yellow-300">Staff</p>
+                        <p className="text-xs md:text-sm text-purple-200 uppercase tracking-wider mt-1">Engineer, Apple</p>
+                    </div>
+                    <div className="bg-white bg-opacity-10 rounded-xl py-4 px-2">
+                        <p className="text-2xl md:text-3xl font-bold text-yellow-300">40+</p>
+                        <p className="text-xs md:text-sm text-purple-200 uppercase tracking-wider mt-1">Engineers Coached</p>
+                    </div>
+                    <div className="bg-white bg-opacity-10 rounded-xl py-4 px-2">
+                        <p className="text-2xl md:text-3xl font-bold text-yellow-300">AI</p>
+                        <p className="text-xs md:text-sm text-purple-200 uppercase tracking-wider mt-1">Agent Infra · v1 Shipped</p>
+                    </div>
+                </div>
+
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
                     <ExpandableCard
                         id={1}
@@ -156,8 +177,8 @@ const AboutSection = () => {
                         </div>
                     </ExpandableCard>
                 </div>
-            </div >
-        </div >
+            </div>
+        </div>
     )
 }
 

--- a/website/src/components/landing-page/coaching-section.tsx
+++ b/website/src/components/landing-page/coaching-section.tsx
@@ -1,26 +1,57 @@
 const CoachingSection = () => {
     return (
-        <div className="min-h-screen bg-gradient-to-b from-indigo-900 to-purple-800 flex items-center justify-center p-8 pt-24 md:pt-12">
-            <div className="max-w-4xl text-center text-white">
-                <h2 className="text-3xl md:text-4xl font-bold mb-6">Speaking/Coaching</h2>
-                <p className="text-lg md:text-xl mb-12">Discover how we can work together to unlock your potential.</p>
+        <div className="bg-gradient-to-b from-indigo-900 to-purple-800 py-20 md:py-28 px-8">
+            <div className="max-w-6xl mx-auto text-center text-white">
+                <h2 className="text-3xl md:text-4xl font-bold mb-6">Speaking / Coaching</h2>
+                <p className="text-lg md:text-xl mb-10 max-w-2xl mx-auto">
+                    Helping engineers, founders, and teams navigate the shift to AI-first careers and products.
+                </p>
+
+                {/* Social proof strip */}
+                <div className="flex flex-wrap justify-center gap-6 mb-12 md:mb-16 text-sm">
+                    <div className="flex items-center gap-2 bg-white bg-opacity-10 px-4 py-2 rounded-full">
+                        <span className="text-yellow-300 font-bold">40+</span>
+                        <span className="text-purple-200">Engineers &amp; Professionals Mentored</span>
+                    </div>
+                    <div className="flex items-center gap-2 bg-white bg-opacity-10 px-4 py-2 rounded-full">
+                        <span className="text-yellow-300 font-bold">★ 5.0</span>
+                        <span className="text-purple-200">on Topmate</span>
+                    </div>
+                    <div className="flex items-center gap-2 bg-white bg-opacity-10 px-4 py-2 rounded-full">
+                        <span className="text-yellow-300 font-bold">AI · Startups · Career Growth</span>
+                        <span className="text-purple-200">Topics</span>
+                    </div>
+                </div>
+
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                    <div className="bg-indigo-800 bg-opacity-50 p-6 rounded-lg">
+                    <div className="bg-indigo-800 bg-opacity-50 p-6 rounded-lg text-left">
                         <h3 className="text-xl md:text-2xl font-semibold mb-4">One-on-One Coaching</h3>
-                        <p className="text-sm md:text-base">Personalized guidance to help you overcome obstacles and achieve your goals. I’ve mentored 20-30 professionals, providing career direction and advice, with testimonials available on <a href="https://topmate.io/rahat_khanna" className="underline text-gray-300">my Topmate profile.</a></p>
+                        <p className="text-sm md:text-base text-gray-200">Personalized guidance for engineers navigating the AI era — career pivots, technical growth, and leadership transitions. 40+ professionals coached, with reviews on <a href="https://topmate.io/rahat_khanna" className="underline text-purple-300 hover:text-white">my Topmate profile.</a></p>
                     </div>
-                    <div className="bg-indigo-800 bg-opacity-50 p-6 rounded-lg">
-                        <h3 className="text-xl md:text-2xl font-semibold mb-4">Workshops & Seminars</h3>
-                        <p className="text-sm md:text-base">Interactive sessions designed to inspire and equip you with practical tools for success. Past events include specialized workshops for technology teams and leadership development.</p>
+                    <div className="bg-indigo-800 bg-opacity-50 p-6 rounded-lg text-left">
+                        <h3 className="text-xl md:text-2xl font-semibold mb-4">Workshops &amp; Seminars</h3>
+                        <p className="text-sm md:text-base text-gray-200">Hands-on sessions for technology teams on AI tooling, engineering velocity, and building with LLMs. Covers practical patterns from real production systems — not just theory.</p>
                     </div>
-                    <div className="bg-indigo-800 bg-opacity-50 p-6 rounded-lg">
+                    <div className="bg-indigo-800 bg-opacity-50 p-6 rounded-lg text-left">
                         <h3 className="text-xl md:text-2xl font-semibold mb-4">Startup Growth Advisory</h3>
-                        <p className="text-sm md:text-base">Tailored advisory programs to help startups scale, refine processes, and foster innovation. I’ve helped several startups grow by connecting them to VCs and important tech founders, ensuring they have the strategic support needed to thrive.</p>
+                        <p className="text-sm md:text-base text-gray-200">Tactical advisory for early-stage startups: architecture, hiring, VC positioning, and product–market fit. I&apos;ve connected founders to VCs and key networks across the AI ecosystem.</p>
                     </div>
-                    <div className="bg-indigo-800 bg-opacity-50 p-6 rounded-lg">
+                    <div className="bg-indigo-800 bg-opacity-50 p-6 rounded-lg text-left">
                         <h3 className="text-xl md:text-2xl font-semibold mb-4">Speaking Engagements</h3>
-                        <p className="text-sm md:text-base">Inspiring talks that motivate audiences to embrace change and pursue excellence. Topics range from emerging AI trends to building resilient career and startup strategies.</p>
+                        <p className="text-sm md:text-base text-gray-200">Talks on AI infrastructure, the future of engineering, and building resilient tech careers in the post-AI era. Available for conferences, company all-hands, and university events.</p>
                     </div>
+                </div>
+
+                {/* CTA */}
+                <div className="mt-12">
+                    <a
+                        href="https://topmate.io/rahat_khanna"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-block bg-purple-500 hover:bg-purple-400 text-white font-semibold px-8 py-3 rounded-full transition-colors duration-200"
+                    >
+                        Book a Session →
+                    </a>
                 </div>
             </div>
         </div>

--- a/website/src/components/landing-page/contact-section.tsx
+++ b/website/src/components/landing-page/contact-section.tsx
@@ -47,64 +47,108 @@ const ContactSection = () => {
     };
 
     return (
-        <div className="min-h-screen bg-gradient-to-b from-purple-800 to-indigo-900 flex flex-col items-center justify-center p-8 pt-24 md:pt-12">
-            <div className="max-w-4xl text-center text-white">
-                <h2 className="text-4xl font-bold mb-6">Unleash Newsletter</h2>
-                <p className="text-xl mb-12">Subscribe to Unleash for motivational insights, productivity hacks, and the latest in AI tools and tips. I&apos;ll be sharing real-world strategies and systems that I&apos;ve personally used to grow in the fast-evolving tech landscape. Let&apos;s unlock your full potential together!</p>
-            </div>
-            <div className="max-w-md w-full bg-white bg-opacity-10 p-8 rounded-lg backdrop-blur-md">
-                <form className="space-y-6" onSubmit={handleSubmit}>
-                    <div>
-                        <label htmlFor="name" className="block text-sm font-medium text-purple-200">Name</label>
-                        <input
-                            type="text"
-                            id="name"
-                            name="name"
-                            value={formData.name}
-                            onChange={handleChange}
-                            className="mt-1 block w-full rounded-md bg-purple-100 border-transparent text-gray-700 focus:border-purple-500 focus:bg-white focus:ring-0"
-                        />
-                    </div>
-                    <div>
-                        <label htmlFor="email" className="block text-sm font-medium text-purple-200">Email</label>
-                        <input
-                            type="email"
-                            id="email"
-                            name="email"
-                            value={formData.email}
-                            onChange={handleChange}
-                            className="mt-1 block w-full rounded-md bg-purple-100 border-transparent text-gray-700 focus:border-purple-500 focus:bg-white focus:ring-0"
-                            required
-                            pattern="[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$"
-                            title="Please enter a valid email address."
-                        />
-                    </div>
-                    <div>
-                        <label htmlFor="message" className="block text-sm font-medium text-purple-200">What motivates you to subscribe? <span className="text-xs">(optional)</span></label>
-                        <textarea
-                            id="message"
-                            name="message"
-                            rows={4}
-                            value={formData.message}
-                            onChange={handleChange}
-                            className="mt-1 block w-full rounded-md bg-purple-100 border-transparent text-gray-700 focus:border-purple-500 focus:bg-white focus:ring-0"
-                        ></textarea>
-                    </div>
-                    <div>
-                        <button
-                            type="submit"
-                            className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-purple-600 hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500"
-                            disabled={isSubmitting}
-                        >
-                            {isSubmitting ? 'Sending...' : 'Send Message'}
-                        </button>
-                    </div>
-                    {submitMessage && (
-                        <div className={`text-center ${submitMessage.includes('error') ? 'text-red-400' : 'text-green-400'}`}>
-                            {submitMessage}
+        <div className="bg-gradient-to-b from-purple-800 to-indigo-900 py-20 md:py-28 px-8">
+            <div className="max-w-6xl mx-auto">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-12 md:gap-16 items-start">
+
+                    {/* Left — newsletter value props */}
+                    <div className="text-white">
+                        <h2 className="text-4xl font-bold mb-6">Unleash Newsletter</h2>
+                        <p className="text-lg text-purple-200 mb-8">
+                            Real-world AI strategies, engineering insights, and career moves — from the frontier of AI-native systems. No fluff.
+                        </p>
+                        <ul className="space-y-4 text-purple-100">
+                            <li className="flex items-start gap-3">
+                                <span className="text-yellow-300 mt-0.5 text-lg">→</span>
+                                <span>Practical AI tooling and workflow tips from production systems at Apple</span>
+                            </li>
+                            <li className="flex items-start gap-3">
+                                <span className="text-yellow-300 mt-0.5 text-lg">→</span>
+                                <span>Career growth insights for engineers navigating the AI era</span>
+                            </li>
+                            <li className="flex items-start gap-3">
+                                <span className="text-yellow-300 mt-0.5 text-lg">→</span>
+                                <span>Lessons from 13+ years across Apple, Flipkart, and my own ventures</span>
+                            </li>
+                            <li className="flex items-start gap-3">
+                                <span className="text-yellow-300 mt-0.5 text-lg">→</span>
+                                <span>Honest takes on the future of software engineering</span>
+                            </li>
+                        </ul>
+
+                        {/* Social links */}
+                        <div className="mt-10 flex flex-wrap gap-4">
+                            <a href="https://linkedin.com/in/rahatkhanna" target="_blank" rel="noopener noreferrer"
+                                className="flex items-center gap-2 bg-white bg-opacity-10 hover:bg-opacity-20 px-4 py-2 rounded-full text-sm text-white transition-colors">
+                                LinkedIn
+                            </a>
+                            <a href="https://topmate.io/rahat_khanna" target="_blank" rel="noopener noreferrer"
+                                className="flex items-center gap-2 bg-white bg-opacity-10 hover:bg-opacity-20 px-4 py-2 rounded-full text-sm text-white transition-colors">
+                                Topmate
+                            </a>
+                            <a href="https://github.com/mappmechanic" target="_blank" rel="noopener noreferrer"
+                                className="flex items-center gap-2 bg-white bg-opacity-10 hover:bg-opacity-20 px-4 py-2 rounded-full text-sm text-white transition-colors">
+                                GitHub
+                            </a>
                         </div>
-                    )}
-                </form>
+                    </div>
+
+                    {/* Right — signup form */}
+                    <div className="bg-white bg-opacity-10 p-8 rounded-xl backdrop-blur-md">
+                        <form className="space-y-6" onSubmit={handleSubmit}>
+                            <div>
+                                <label htmlFor="name" className="block text-sm font-medium text-purple-200">Name</label>
+                                <input
+                                    type="text"
+                                    id="name"
+                                    name="name"
+                                    value={formData.name}
+                                    onChange={handleChange}
+                                    className="mt-1 block w-full rounded-md bg-purple-100 border-transparent text-gray-700 focus:border-purple-500 focus:bg-white focus:ring-0"
+                                />
+                            </div>
+                            <div>
+                                <label htmlFor="email" className="block text-sm font-medium text-purple-200">Email</label>
+                                <input
+                                    type="email"
+                                    id="email"
+                                    name="email"
+                                    value={formData.email}
+                                    onChange={handleChange}
+                                    className="mt-1 block w-full rounded-md bg-purple-100 border-transparent text-gray-700 focus:border-purple-500 focus:bg-white focus:ring-0"
+                                    required
+                                    pattern="[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$"
+                                    title="Please enter a valid email address."
+                                />
+                            </div>
+                            <div>
+                                <label htmlFor="message" className="block text-sm font-medium text-purple-200">What brings you here? <span className="text-xs">(optional)</span></label>
+                                <textarea
+                                    id="message"
+                                    name="message"
+                                    rows={4}
+                                    value={formData.message}
+                                    onChange={handleChange}
+                                    className="mt-1 block w-full rounded-md bg-purple-100 border-transparent text-gray-700 focus:border-purple-500 focus:bg-white focus:ring-0"
+                                ></textarea>
+                            </div>
+                            <div>
+                                <button
+                                    type="submit"
+                                    className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-purple-600 hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500"
+                                    disabled={isSubmitting}
+                                >
+                                    {isSubmitting ? 'Sending...' : 'Subscribe →'}
+                                </button>
+                            </div>
+                            {submitMessage && (
+                                <div className={`text-center ${submitMessage.includes('error') ? 'text-red-400' : 'text-green-400'}`}>
+                                    {submitMessage}
+                                </div>
+                            )}
+                        </form>
+                    </div>
+                </div>
             </div>
         </div>
     )

--- a/website/src/components/landing-page/portfolio-section.tsx
+++ b/website/src/components/landing-page/portfolio-section.tsx
@@ -1,9 +1,9 @@
 const PortfolioSection = () => {
     return (
-        <div className="min-h-screen bg-gradient-to-b from-indigo-900 to-purple-800 flex items-center justify-center p-8 pt-24 md:pt-12">
-            <div className="max-w-4xl text-center text-white">
+        <div className="bg-gradient-to-b from-indigo-900 to-purple-800 py-20 md:py-28 px-8">
+            <div className="max-w-6xl mx-auto text-center text-white">
                 <h2 className="text-4xl font-bold mb-6">Portfolio</h2>
-                <p className="text-xl mb-12">Showcasing my top projects and achievements.</p>
+                <p className="text-xl mb-12">A selection of the systems, platforms, and products I&apos;ve shipped.</p>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
                     {/* Featured AI project — full width */}
                     <div className="md:col-span-2 bg-blue-900 bg-opacity-70 border border-blue-400 border-opacity-40 p-6 rounded-lg text-left">

--- a/website/src/components/layout/animated-landing-text.tsx
+++ b/website/src/components/layout/animated-landing-text.tsx
@@ -51,15 +51,22 @@ const AnimatedLandingText = () => {
     }
   };
 
+  const stats = [
+    { label: 'Staff Engineer', sub: 'Apple' },
+    { label: '13+ Years', sub: 'Engineering' },
+    { label: '40+', sub: 'Mentored' },
+    { label: 'AI Agents', sub: 'Infrastructure' },
+  ];
+
   return (
-    <motion.div 
-      className="flex flex-col items-center justify-center h-screen text-white"
+    <motion.div
+      className="flex flex-col items-center justify-center min-h-screen text-white py-24 px-8"
       style={{ backgroundColor: '#382c85' }}
       variants={containerVariants}
       initial="hidden"
       animate="visible"
     >
-      <motion.h1 
+      <motion.h1
         className="text-7xl md:text-10xl sm:text-8xl font-bold mb-6 text-transparent bg-clip-text bg-gradient-to-r from-white to-purple-300"
         variants={itemVariants}
       >
@@ -71,8 +78,8 @@ const AnimatedLandingText = () => {
       >
         <span className="mr-4 text-purple-200">the future with</span>
       </motion.div>
-      <motion.div 
-        className="text-5xl md:text-7xl sm:text-6xl font-semibold flex items-center"
+      <motion.div
+        className="text-5xl md:text-7xl sm:text-6xl font-semibold flex items-center mb-16"
         variants={itemVariants}
       >
         <AnimatePresence mode="wait">
@@ -87,6 +94,22 @@ const AnimatedLandingText = () => {
             {subtitles[currentSubtitle]}
           </motion.span>
         </AnimatePresence>
+      </motion.div>
+
+      {/* Quick-stat badges — fill hero space on large screens */}
+      <motion.div
+        className="flex flex-wrap justify-center gap-4"
+        variants={itemVariants}
+      >
+        {stats.map((stat) => (
+          <div
+            key={stat.label}
+            className="flex flex-col items-center bg-white bg-opacity-10 border border-white border-opacity-20 rounded-xl px-6 py-3 backdrop-blur-sm"
+          >
+            <span className="text-lg font-bold text-white">{stat.label}</span>
+            <span className="text-xs text-purple-200 mt-0.5 uppercase tracking-widest">{stat.sub}</span>
+          </div>
+        ))}
       </motion.div>
     </motion.div>
   );


### PR DESCRIPTION
## Summary

- **Root cause fixed**: All sections used `min-h-screen flex items-center justify-center` — forcing 100vh per section and creating large empty voids on wide viewports. Replaced with vertical padding (`py-20 md:py-28`) throughout.
- **Content widened**: All sections expanded from `max-w-4xl` → `max-w-6xl` to fill horizontal space on large screens.
- **Hero**: Added 4 quick-stat badges below the animated subtitle (Staff Engineer · 13+ Years · 40+ Mentored · AI Agents).
- **About Me**: New 4-cell stats strip between bio and expandable cards (13+ yrs / Staff Eng / 40+ Coached / AI Infra v1 ✓).
- **Portfolio**: Subtitle copy updated; `min-h-screen` removed.
- **Coaching**: Updated stale mentoring count (20–30 → 40+); added social-proof pills; left-aligned card text for readability; added "Book a Session →" CTA.
- **Newsletter**: Two-column layout on md+ (value props with bullet list + social links on left, signup form on right).

## Test plan

- [ ] Check all sections at 1280px, 1600px, and 1920px widths — no empty purple voids
- [ ] Check mobile (375px) — layout stacks correctly, no regressions
- [ ] Verify all links (Topmate, LinkedIn, GitHub) open correctly
- [ ] Deploy preview on Vercel and do a final visual pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)