### PR TITLE
Rebrand site to AI Agent infra focus and migrate to Bun

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,5 @@
   "rootDirectory": "website",
   "installCommand": "bun install",
   "buildCommand": "bun run build",
-  "devCommand": "bun run dev",
-  "framework": "nextjs"
+  "devCommand": "bun run dev"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "installCommand": "cd website && bun install",
-  "buildCommand": "cd website && bun run build",
-  "devCommand": "cd website && bun run dev"
+  "installCommand": "bun install",
+  "buildCommand": "bun run build",
+  "devCommand": "bun run dev"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,5 @@
 {
-  "rootDirectory": "website",
-  "installCommand": "bun install",
-  "buildCommand": "bun run build",
-  "devCommand": "bun run dev"
+  "installCommand": "cd website && bun install",
+  "buildCommand": "cd website && bun run build",
+  "devCommand": "cd website && bun run dev"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "rootDirectory": "website",
+  "installCommand": "bun install",
+  "buildCommand": "bun run build",
+  "devCommand": "bun run dev",
+  "framework": "nextjs"
+}

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+package-lock.json
 
 # bun
 bun.lockb

--- a/website/src/components/landing-page/about-section.tsx
+++ b/website/src/components/landing-page/about-section.tsx
@@ -7,7 +7,7 @@ const AboutSection = () => {
             <div className="max-w-6xl mx-auto text-center text-white">
                 <h2 className="text-2xl md:text-4xl font-bold mb-6">About Me</h2>
                 <p className="text-base md:text-xl mb-8 md:mb-12 max-w-3xl mx-auto">
-                    Staff Software Engineer at Apple, where I build the infrastructure for AI Agents — observability pipelines, evaluation frameworks, and the platforms that make AI reliable at scale. 13+ years of engineering across Apple, Flipkart, and my own ventures, now fully focused on the frontier of AI-native systems.
+                    Staff Engineer at Apple, building infrastructure for AI Agents. 13+ years of engineering across Apple, Flipkart, and my own ventures, now fully focused on the frontier of AI-native systems.
                 </p>
 
                 {/* Stats strip */}
@@ -45,7 +45,7 @@ const AboutSection = () => {
                             <ul>
                                 <li className="mb-2"><strong>AI Agent Infrastructure</strong><br /> Building observability pipelines and evaluation frameworks for LLM-based agents in production.</li>
                                 <li className="mb-2"><strong>LLM Observability & Evaluation</strong><br /> Designing systems that make AI behaviour measurable, debuggable, and reliable at scale.</li>
-                                <li className="mb-2"><strong>Platform Engineering</strong><br /> Full-stack platforms in Python & React powering data and ML workflows at Apple.</li>
+                                <li className="mb-2"><strong>Platform Engineering</strong><br /> Full-stack platforms in Python & React powering data and ML workflows at scale.</li>
                                 <li className="mb-2"><strong>Engineering Leadership</strong><br /> Driving cross-functional delivery for high-impact products used by millions globally.</li>
                                 <li className="mb-2"><strong>Technical Mentorship</strong><br /> Coaching 40+ engineers and professionals toward career growth in the AI era.</li>
                             </ul>
@@ -59,8 +59,8 @@ const AboutSection = () => {
                         title="Career Highlights"
                         previewContent={
                             <>
-                                <p className="text-gray-600 text-xs">Staff Sw Eng, Data & ML Platform <span className="text-sm font-bold">2021-Present</span><br /><span className="text-purple-500 text-sm font-semibold">Apple Inc</span></p>
-                                <p className="text-gray-600 text-xs">Senior Sw Eng <span className="text-sm font-bold">2017-2021</span><br /><span className="text-purple-500 text-sm font-semibold">Apple India</span></p>
+                                <p className="text-gray-600 text-xs">Staff Software Engineer <span className="text-sm font-bold">2022–Present</span><br /><span className="text-purple-500 text-sm font-semibold">Apple Inc</span></p>
+                                <p className="text-gray-600 text-xs">Senior Software Engineer <span className="text-sm font-bold">2017–2022</span><br /><span className="text-purple-500 text-sm font-semibold">Apple India</span></p>
                                 <p className="text-gray-600 text-xs">Senior UI Eng <span className="text-sm font-bold">2015-2017</span><br /><span className="text-purple-500 text-sm font-semibold">Flipkart (Walmart)</span></p>
                             </>
                         }
@@ -71,7 +71,7 @@ const AboutSection = () => {
                             </p>
                             <ul className="relative list-none pl-6 space-y-8 border-l-2 border-gray-300">
                                 <li className="relative pl-4 before:absolute before:left-[-30px] before:top-1/2 before:w-4 before:h-4 before:bg-purple-500 before:rounded-full before:border-2 before:border-gray-300">
-                                    <strong>Apple - Staff Software Engineer, Data & ML Platform (Oct 2022 - Present)</strong>: Building AI Agent infrastructure — observability, evaluation frameworks, and Python & React platforms powering ML workflows at scale.
+                                    <strong>Apple - Staff Software Engineer (Oct 2022 - Present)</strong>: Building infrastructure for AI Agents — working across observability, evaluation, and platform engineering at scale.
                                 </li>
                                 <li className="relative pl-4 before:absolute before:left-[-30px] before:top-1/2 before:w-4 before:h-4 before:bg-purple-500 before:rounded-full before:border-2 before:border-gray-300">
                                     <strong>Apple - Senior Software Engineer (May 2020 - Oct 2022)</strong>: Managed web experiences for Apple Books, TV, and Podcasts, collaborating with cross-functional teams to deliver impactful solutions.
@@ -86,7 +86,7 @@ const AboutSection = () => {
                                     <strong>Flipkart - Senior UI Engineer (May 2015 - May 2016)</strong>: Enhanced Flipkart&apos;s e-commerce UI/UX, driving engagement and optimizing checkout flows.
                                 </li>
                                 <li className="relative pl-4 before:absolute before:left-[-30px] before:top-1/2 before:w-4 before:h-4 before:bg-purple-500 before:rounded-full before:border-2 before:border-gray-300">
-                                    <strong>Genpact - Technical Consultant (May 2015 - May 2016)</strong>: Developed AngularJS web apps and hybrid mobile apps, boosting client performance and scalability.
+                                    <strong>Genpact - Technical Consultant (May 2014 - May 2015)</strong>: Developed AngularJS web apps and hybrid mobile apps, boosting client performance and scalability.
                                 </li>
                                 <li className="relative pl-4 before:absolute before:left-[-30px] before:top-1/2 before:w-4 before:h-4 before:bg-purple-500 before:rounded-full before:border-2 before:border-gray-300">
                                     <strong>Genpact - Senior Associate (May 2012 - May 2014)</strong>: Built mobile solutions and healthcare web apps adopted by 3,000+ users globally.

--- a/website/src/components/landing-page/contact-section.tsx
+++ b/website/src/components/landing-page/contact-section.tsx
@@ -60,7 +60,7 @@ const ContactSection = () => {
                         <ul className="space-y-4 text-purple-100">
                             <li className="flex items-start gap-3">
                                 <span className="text-yellow-300 mt-0.5 text-lg">→</span>
-                                <span>Practical AI tooling and workflow tips from production systems at Apple</span>
+                                <span>Practical AI tooling and workflow tips from real production systems</span>
                             </li>
                             <li className="flex items-start gap-3">
                                 <span className="text-yellow-300 mt-0.5 text-lg">→</span>
@@ -68,7 +68,7 @@ const ContactSection = () => {
                             </li>
                             <li className="flex items-start gap-3">
                                 <span className="text-yellow-300 mt-0.5 text-lg">→</span>
-                                <span>Lessons from 13+ years across Apple, Flipkart, and my own ventures</span>
+                                <span>Lessons from 13+ years across big tech, startups, and my own ventures</span>
                             </li>
                             <li className="flex items-start gap-3">
                                 <span className="text-yellow-300 mt-0.5 text-lg">→</span>

--- a/website/src/components/landing-page/portfolio-section.tsx
+++ b/website/src/components/landing-page/portfolio-section.tsx
@@ -8,14 +8,13 @@ const PortfolioSection = () => {
                     {/* Featured AI project — full width */}
                     <div className="md:col-span-2 bg-blue-900 bg-opacity-70 border border-blue-400 border-opacity-40 p-6 rounded-lg text-left">
                         <div className="flex items-center gap-3 mb-3">
-                            <span className="text-xs font-semibold uppercase tracking-widest text-blue-300 bg-blue-800 bg-opacity-60 px-3 py-1 rounded-full">AI Infrastructure · Apple</span>
+                            <span className="text-xs font-semibold uppercase tracking-widest text-blue-300 bg-blue-800 bg-opacity-60 px-3 py-1 rounded-full">AI Infrastructure</span>
                         </div>
                         <h3 className="text-2xl font-semibold mb-3">Agent Observability & Evaluation Platform</h3>
                         <p className="text-gray-200 mb-3">
-                            End-to-end platform for monitoring, tracing, and evaluating AI Agents in production. Built at Apple — powers reliability and quality assurance for LLM-based systems at scale, with real-time observability pipelines and automated evaluation frameworks.
+                            End-to-end platform for monitoring, tracing, and evaluating AI Agents in production — powering reliability and quality assurance for LLM-based systems at scale, with real-time observability pipelines and automated evaluation frameworks.
                         </p>
-                        <p className="text-sm text-blue-300 font-medium">Python · React · LLM Evaluation · Observability · Data & ML Platform</p>
-                        <p className="text-xs text-gray-400 mt-2 italic">Internal platform — Apple Confidential</p>
+                        <p className="text-sm text-blue-300 font-medium">Python · React · LLM Evaluation · Observability · Platform Engineering</p>
                     </div>
                     <div className="bg-indigo-800 bg-opacity-50 p-6 rounded-lg">
                         <h3 className="text-2xl font-semibold mb-4">100 Best Albums - Apple Music</h3>


### PR DESCRIPTION
## Summary

- **Content rebrand**: Rewrote hero, about, coaching, portfolio, and contact sections to reflect Staff Engineer / AI Agent infrastructure identity at Apple
- **New UI elements**: Added stats strips, social proof badges (40+ mentored, ★5.0 Topmate), coaching CTA button, and a featured portfolio card for the Agent Observability & Evaluation Platform
- **Bun migration**: Switched package manager from yarn to bun (`bunfig.toml`, `bun.lock`, updated `.gitignore` and `package.json`)
- **Deployment**: Added `vercel.json` config and `typecheck` script

## Test Plan

- [x] `bun run build` passes with no errors (warnings only, pre-existing)
- [ ] Verify hero animated text cycles through new subtitles: AI Agents, Observability, Scale, Impact, You
- [ ] Verify stat badges render correctly on mobile and desktop
- [ ] Verify "Book a Session →" CTA links to Topmate
- [ ] Verify newsletter form layout renders as 2-column on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)